### PR TITLE
Adds an option to tune the cgroup settings. Disabled by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+options:
+  enable-cgroups:
+    type: boolean
+    default: false
+    description: |
+     Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING
+     changing this option will reboot the host - use with caution on production
+     services

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -2,6 +2,7 @@ import os
 from subprocess import check_call
 
 from charmhelpers.core.hookenv import status_set
+from charmhelpers.core.hookenv import config
 
 from charms.reactive import set_state
 from charms.reactive import hook
@@ -44,6 +45,12 @@ def install():
     check_call(['usermod', '-aG', 'docker', 'ubuntu'])
 
 
+@when_not('cgroups.modified')
+def enable_grub_cgroups():
+    cfg = config()
+    if cfg.get('enable-cgroups'):
+        check_call(['scripts/enable_grub_cgroups.sh'])
+        set_state('cgroups.modified')
 
 @when('docker.ready')
 @when_not('docker.available')

--- a/scripts/enable_grub_cgroups.sh
+++ b/scripts/enable_grub_cgroups.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Edits the grub defaults file to append the GRUB_CMDLINE_LINUX options and executes a
+#  `juju-reboot` to reboot the machine.
+
+status-set maintenance "Configuring and updating grub"
+
+sed -i  's/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\"cgroup_enable=memory swapaccount=1\"/' /etc/default/grub
+update-grub
+status-set maintenance "Rebooting the machine"
+
+juju-reboot


### PR DESCRIPTION
This causes a machine reboot on first run. It only recycles the host
to complete the memory accounting modules.

Updates #15 and #16