### PR TITLE
Compose wrapper

### DIFF
--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -10,29 +10,31 @@ class Compose:
         self.workspace = workspace
 
     def start_service(self, service=None):
-        with chdir(self.workspace):
-            if service:
-                cmd = "docker-compose up -d {}".format(service)
-            else:
-                cmd = "docker-compose up -d"
-            self.run(cmd)
+        if service:
+            cmd = "docker-compose up -d {}".format(service)
+        else:
+            cmd = "docker-compose up -d"
+        self.run(cmd)
 
     def kill_service(self, service=None):
-        with chdir(self.workspace):
-            if service:
-                cmd = "docker-compose kill -d {}".format(service)
-            else:
-                cmd = "docker-compose kill"
-            self.run(cmd)
+        if service:
+            cmd = "docker-compose kill -d {}".format(service)
+        else:
+            cmd = "docker-compose kill"
+        self.run(cmd)
 
     def run(self, cmd):
-        check_call(split(cmd))
+        with chdir(self.workspace):
+            check_call(split(cmd))
 
 # This is helpful for setting working directory context
 @contextmanager
 def chdir(path):
     '''Change the current working directory to a different directory to run
     commands and return to the previous directory after the command is done.'''
+    if not os.path.exists("{}/docker-compose.yml".format(self.workspace) or
+    not os.path.exists("{}"/docker-compose.yaml)):
+        raise OSError "docker-compose.yml not found in workspace"
     old_dir = os.getcwd()
     os.chdir(path)
     yield

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -8,6 +8,7 @@ from subprocess import check_call
 class Compose:
     def __init__(self, workspace):
         self.workspace = workspace
+        self.validate_workspace()
 
     def start_service(self, service=None):
         if service:
@@ -27,14 +28,18 @@ class Compose:
         with chdir(self.workspace):
             check_call(split(cmd))
 
+
+    def validate_workspace(self):
+        dcyml = os.path.isfile("{}/docker-compose.yml".format(self.workspace))
+        dcyaml = os.path.isfile("{}/docker-compose.yaml".format(self.workspace))
+        if not dcyml and not dcyaml:
+            raise OSError("docker-compose.yml not found in workspace")
+
 # This is helpful for setting working directory context
 @contextmanager
 def chdir(path):
     '''Change the current working directory to a different directory to run
     commands and return to the previous directory after the command is done.'''
-    if not os.path.exists("{}/docker-compose.yml".format(self.workspace) or
-    not os.path.exists("{}/docker-compose.yaml".format(self.workspace))):
-        raise OSError "docker-compose.yml not found in workspace"
     old_dir = os.getcwd()
     os.chdir(path)
     yield

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -33,7 +33,7 @@ def chdir(path):
     '''Change the current working directory to a different directory to run
     commands and return to the previous directory after the command is done.'''
     if not os.path.exists("{}/docker-compose.yml".format(self.workspace) or
-    not os.path.exists("{}"/docker-compose.yaml)):
+    not os.path.exists("{}/docker-compose.yaml".format(self.workspace))):
         raise OSError "docker-compose.yml not found in workspace"
     old_dir = os.getcwd()
     os.chdir(path)

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -1,0 +1,39 @@
+import os
+
+from contextlib import contextmanager
+from shlex import split
+from subprocess import check_call
+
+# Wrapper and convenience methods for charming w/ docker compose in python
+class Compose:
+    def __init__(self, workspace):
+        self.workspace = workspace
+
+    def start_service(self, service=None):
+        with chdir(self.workspace):
+            if service:
+                cmd = "docker-compose up -d {}".format(service)
+            else:
+                cmd = "docker-compose up -d"
+            self.run(cmd)
+
+    def kill_service(self, service=None):
+        with chdir(self.workspace):
+            if service:
+                cmd = "docker-compose kill -d {}".format(service)
+            else:
+                cmd = "docker-compose kill"
+            self.run(cmd)
+
+    def run(self, cmd):
+        check_call(split(cmd))
+
+# This is helpful for setting working directory context
+@contextmanager
+def chdir(path):
+    '''Change the current working directory to a different directory to run
+    commands and return to the previous directory after the command is done.'''
+    old_dir = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(old_dir)

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -45,6 +45,7 @@ def install():
     check_call(['usermod', '-aG', 'docker', 'ubuntu'])
 
 
+@when('docker.ready')
 @when_not('cgroups.modified')
 def enable_grub_cgroups():
     cfg = config()


### PR DESCRIPTION
Adds a docker-compose lib stub (early iteration shipping w/ the charm)

This will eventually move to its own pypi module. For now, exploratory dev shipping w/ the docker charm.

This includes a wrapper class to reduce overall code complexity when consuming docker-compose based formations. You can use this class like the following example code:

    from charms.docker.compose include Compose
    c = Compose('files/mycluster')
    c.start_service()  # starts all services in docker-compose.yml
    c.stop_service('nginx')  # stops nginx listed in docker-compose.yml

Arguments to the Compose Initializer:

workspace - path to find the docker-compose.yaml or docker-compose.yml

This class is a light weight wrapper, and subject to change.