### PR TITLE
Service wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .tox
 .cache
 *.pyc
+.coverage
+.unit-state.db

--- a/lib/charms/docker/__init__.py
+++ b/lib/charms/docker/__init__.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+
+from contextlib import contextmanager
+from shlex import split
+
+from workspace import Workspace
+
+# Wrapper and convenience methods for charming w/ docker in python
+class Docker:
+    '''
+    Wrapper class to communicate with the Docker daemon on behalf of
+    a charmer. Provides stateless operations of a running docker daemon
+    '''
+
+    def __init__(self, socket="unix:///var/run/docker.sock", workspace=None):
+        '''
+        @param socket - URI to the Docker daemon socket
+            default: unix://var/run/docker.sock
+
+        @param workspace - Path to directory containing a Dockerfile
+            default: None
+        '''
+        self.socket = socket
+        if workspace:
+            self.workspace = Workspace(workspace)
+
+    def running(self):
+        '''
+        Predicate method to determine if the daemon we are talking to is
+        actually online and recieving events.
+
+        ex: bootstrap = Docker(socket="unix://var/run/docker-boostrap.sock")
+        bootstrap.running()
+        > True
+        '''
+        # TODO: Add TCP:// support for running check
+        return os.path.isfile(self.socket)
+
+    def run(self, image, options="", volumes=[], ports=[]):
+        volumes = " --volume=".join(volumes)
+        ports = " -p".join(ports)
+        cmd = "docker run {opts} {vols} {ports} {image}".format(
+            opts=options, vols=volumes, ports=ports, image=image)
+
+        try:
+            subprocess.check_output(split(cmd))
+        except subprocess.CalledProcessError as expec:
+            print "Error: ", expect.returncode, expect.output

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -10,29 +10,31 @@ class Compose:
         self.workspace = workspace
 
     def start_service(self, service=None):
-        with chdir(self.workspace):
-            if service:
-                cmd = "docker-compose up -d {}".format(service)
-            else:
-                cmd = "docker-compose up -d"
-            self.run(cmd)
+        if service:
+            cmd = "docker-compose up -d {}".format(service)
+        else:
+            cmd = "docker-compose up -d"
+        self.run(cmd)
 
     def kill_service(self, service=None):
-        with chdir(self.workspace):
-            if service:
-                cmd = "docker-compose kill -d {}".format(service)
-            else:
-                cmd = "docker-compose kill"
-            self.run(cmd)
+        if service:
+            cmd = "docker-compose kill -d {}".format(service)
+        else:
+            cmd = "docker-compose kill"
+        self.run(cmd)
 
     def run(self, cmd):
-        check_call(split(cmd))
+        with chdir(self.workspace):
+            check_call(split(cmd))
 
 # This is helpful for setting working directory context
 @contextmanager
 def chdir(path):
     '''Change the current working directory to a different directory to run
     commands and return to the previous directory after the command is done.'''
+    if not os.path.exists("{}/docker-compose.yml".format(self.workspace) or
+    not os.path.exists("{}"/docker-compose.yaml)):
+        raise OSError "docker-compose.yml not found in workspace"
     old_dir = os.getcwd()
     os.chdir(path)
     yield

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -2,24 +2,45 @@ import os
 
 from contextlib import contextmanager
 from shlex import split
-from subprocess import check_call
+from subprocess import check_output
 from workspace import Workspace
 
 # Wrapper and convenience methods for charming w/ docker compose in python
 class Compose:
-    def __init__(self, workspace, strict=False):
+    def __init__(self, workspace, strict=True):
+        '''
+        Object to manage working with Docker-Compose on the CLI. exposes
+        a natural language for performing common tasks with docker in
+        juju charms.
+
+        @param workspace - Define the CWD for docker-compose execution
+
+        @param strict - Enable/disable workspace validation
+        '''
         self.workspace = Workspace(workspace)
         if strict:
             self.workspace.validate()
 
-    def start_service(self, service=None):
+    def up(self, service=None):
+        '''
+        Convenience method that wraps `docker-compose up`
+
+        usage: c.up('nginx')  to start the 'nginx' service from the
+        defined `docker-compose.yml` as a daemon
+        '''
         if service:
             cmd = "docker-compose up -d {}".format(service)
         else:
             cmd = "docker-compose up -d"
         self.run(cmd)
 
-    def kill_service(self, service=None):
+    def kill(self, service=None):
+        '''
+        Convenience method that wraps `docker-compose kill`
+
+        usage: c.kill('nginx')  to kill the 'nginx' service from the
+        defined `docker-compose.yml`
+        '''
         if service:
             cmd = "docker-compose kill {}".format(service)
         else:
@@ -27,8 +48,19 @@ class Compose:
         self.run(cmd)
 
     def run(self, cmd):
+        '''
+        chdir sets working context on the workspace
+
+        @param: cmd - String of the command to run. eg: echo "hello world"
+        the string is passed through shlex.parse() for convenience.
+
+        returns STDOUT of command execution
+
+        usage: c.run('docker-compose ps')
+        '''
         with chdir("{}".format(self.workspace)):
-            check_call(split(cmd))
+            out = check_output(split(cmd))
+            return out
 
 
 # This is helpful for setting working directory context

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -8,6 +8,7 @@ from subprocess import check_call
 class Compose:
     def __init__(self, workspace):
         self.workspace = workspace
+        self.validate_workspace()
 
     def start_service(self, service=None):
         if service:
@@ -27,14 +28,18 @@ class Compose:
         with chdir(self.workspace):
             check_call(split(cmd))
 
+
+    def validate_workspace(self):
+        dcyml = os.path.isfile("{}/docker-compose.yml".format(self.workspace))
+        dcyaml = os.path.isfile("{}/docker-compose.yaml".format(self.workspace))
+        if not dcyml and not dcyaml:
+            raise OSError("docker-compose.yml not found in workspace")
+
 # This is helpful for setting working directory context
 @contextmanager
 def chdir(path):
     '''Change the current working directory to a different directory to run
     commands and return to the previous directory after the command is done.'''
-    if not os.path.exists("{}/docker-compose.yml".format(self.workspace) or
-    not os.path.exists("{}/docker-compose.yaml".format(self.workspace))):
-        raise OSError "docker-compose.yml not found in workspace"
     old_dir = os.getcwd()
     os.chdir(path)
     yield

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -33,7 +33,7 @@ def chdir(path):
     '''Change the current working directory to a different directory to run
     commands and return to the previous directory after the command is done.'''
     if not os.path.exists("{}/docker-compose.yml".format(self.workspace) or
-    not os.path.exists("{}"/docker-compose.yaml)):
+    not os.path.exists("{}/docker-compose.yaml".format(self.workspace))):
         raise OSError "docker-compose.yml not found in workspace"
     old_dir = os.getcwd()
     os.chdir(path)

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -3,12 +3,14 @@ import os
 from contextlib import contextmanager
 from shlex import split
 from subprocess import check_call
+from workspace import Workspace
 
 # Wrapper and convenience methods for charming w/ docker compose in python
 class Compose:
-    def __init__(self, workspace):
-        self.workspace = workspace
-        self.validate_workspace()
+    def __init__(self, workspace, strict=False):
+        self.workspace = Workspace(workspace)
+        if strict:
+            self.workspace.validate()
 
     def start_service(self, service=None):
         if service:
@@ -19,21 +21,15 @@ class Compose:
 
     def kill_service(self, service=None):
         if service:
-            cmd = "docker-compose kill -d {}".format(service)
+            cmd = "docker-compose kill {}".format(service)
         else:
             cmd = "docker-compose kill"
         self.run(cmd)
 
     def run(self, cmd):
-        with chdir(self.workspace):
+        with chdir("{}".format(self.workspace)):
             check_call(split(cmd))
 
-
-    def validate_workspace(self):
-        dcyml = os.path.isfile("{}/docker-compose.yml".format(self.workspace))
-        dcyaml = os.path.isfile("{}/docker-compose.yaml".format(self.workspace))
-        if not dcyml and not dcyaml:
-            raise OSError("docker-compose.yml not found in workspace")
 
 # This is helpful for setting working directory context
 @contextmanager

--- a/lib/charms/docker/compose.py
+++ b/lib/charms/docker/compose.py
@@ -1,0 +1,39 @@
+import os
+
+from contextlib import contextmanager
+from shlex import split
+from subprocess import check_call
+
+# Wrapper and convenience methods for charming w/ docker compose in python
+class Compose:
+    def __init__(self, workspace):
+        self.workspace = workspace
+
+    def start_service(self, service=None):
+        with chdir(self.workspace):
+            if service:
+                cmd = "docker-compose up -d {}".format(service)
+            else:
+                cmd = "docker-compose up -d"
+            self.run(cmd)
+
+    def kill_service(self, service=None):
+        with chdir(self.workspace):
+            if service:
+                cmd = "docker-compose kill -d {}".format(service)
+            else:
+                cmd = "docker-compose kill"
+            self.run(cmd)
+
+    def run(self, cmd):
+        check_call(split(cmd))
+
+# This is helpful for setting working directory context
+@contextmanager
+def chdir(path):
+    '''Change the current working directory to a different directory to run
+    commands and return to the previous directory after the command is done.'''
+    old_dir = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(old_dir)

--- a/lib/charms/docker/workspace.py
+++ b/lib/charms/docker/workspace.py
@@ -1,0 +1,39 @@
+import os
+
+class Workspace:
+    '''
+    Docker workspaces are unique in our world, as they can be one of two context
+    dependent things: A Docker build directory, containing only a single
+    Dockerfile, or they can be part of a formation using docker-compose in which
+    they warehouse a docker-compose.yml file.
+
+    Under most situations we only care about the context the charm author wishes
+    to be in, and what implications that has on the workspace to be valid.
+
+    This method simply exposes an overrideable object to determine these
+    characteristics.
+    '''
+    def __init__(self, path, context="compose"):
+        self.path = path
+        self.context = context
+
+    def __str__(self):
+        return self.path
+
+    def __repr__(self):
+        return self.path
+
+    def validate(self):
+        dcyml = os.path.isfile("{}/docker-compose.yml".format(self.path))
+        dcyaml = os.path.isfile("{}/docker-compose.yaml".format(self.path))
+        dfile = os.path.isfile("{}/Dockerfile".format(self.path))
+
+        if self.context == "compose":
+            if not dcyml and not dcyaml:
+                msg = "Missing yaml definition: docker-compose.yml"
+                raise OSError(msg)
+        else:
+            if not dfile:
+                msg = "Missing Dockerfile"
+                raise OSError(msg)
+        return True

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -45,6 +45,7 @@ def install():
     check_call(['usermod', '-aG', 'docker', 'ubuntu'])
 
 
+@when('docker.ready')
 @when_not('cgroups.modified')
 def enable_grub_cgroups():
     cfg = config()

--- a/tox.ini
+++ b/tox.ini
@@ -19,4 +19,4 @@ setenv =
     PYTHONPATH = {toxinidir}/lib
 
 commands =
-    py.test -v {posargs}
+    py.test -v {posargs} --cov=lib.charms.docker --cov-report=term-missing

--- a/unit_tests/test_docker.py
+++ b/unit_tests/test_docker.py
@@ -1,0 +1,42 @@
+from lib.charms.docker import Docker
+from lib.charms import docker
+from mock import patch
+import pytest
+
+class TestDocker:
+
+    @pytest.fixture
+    def docker(self):
+        return Docker()
+
+
+    # There's a pattern to run an isolated docker daemon to run supporting
+    # infrastructure of the primary docker daemon. This bootstrap daemon
+    # runs host only on a socket
+    @pytest.fixture
+    def bootstrap(self):
+        return Docker(socket="unix:///var/run/docker-bootstrap.sock")
+
+    def test_docker_init_defaults(self, docker):
+        docker.socket = "unix:///var/run/docker.sock"
+
+    def test_docker_init_socket(self):
+        docker = Docker(socket="tcp://127.0.0.1:2357")
+        assert docker.socket == "tcp://127.0.0.1:2357"
+
+    def test_docker_init_workspace(self):
+        devel = Docker(workspace="files/tmp")
+        assert "{}".format(devel.workspace) == "files/tmp"
+
+    def test_running(self, bootstrap):
+        with patch('os.path.isfile') as isfilemock:
+            isfilemock.return_value = True
+            assert bootstrap.running() is True
+
+    def test_run(self, docker):
+        with patch('subprocess.check_output') as spmock:
+            docker.run('nginx')
+            spmock.assert_called_with(['docker', 'run', 'nginx'])
+            docker.run('nginx', '-d --name=nginx')
+            spmock.assert_called_with(['docker', 'run', '-d', '--name=nginx',
+             'nginx'])

--- a/unit_tests/test_docker_compose.py
+++ b/unit_tests/test_docker_compose.py
@@ -1,0 +1,64 @@
+from lib.charms.docker.compose import Compose
+from lib.charms.docker import compose
+from mock import patch
+import pytest
+
+class TestCompose:
+
+    # This has limited usefulness, it fails when used with the @patch
+    # decorator. simply pass in compose to any object to gain the
+    # test fixture
+    @pytest.fixture
+    def compose(self):
+        return Compose('files/test', strict=False)
+
+    def test_init_strict(self):
+        with patch('lib.charms.docker.compose.Workspace.validate') as f:
+            c = Compose('test', strict=True)
+            # Is this the beast? is mock() doing the right thing here?
+            f.assert_called_with()
+
+    def test_init_workspace(self, compose):
+        assert "{}".format(compose.workspace) == "files/test"
+
+    def test_start_service(self, compose):
+        with patch('lib.charms.docker.compose.Compose.run') as s:
+            compose.start_service('nginx')
+            expect = 'docker-compose up -d nginx'
+            s.assert_called_with(expect)
+
+    def test_start_default_formation(self, compose):
+        with patch('lib.charms.docker.compose.Compose.run') as s:
+            compose.start_service()
+            expect = 'docker-compose up -d'
+
+    def test_kill_service(self, compose):
+        with patch('lib.charms.docker.compose.Compose.run') as s:
+            compose.kill_service('nginx')
+            expect = 'docker-compose kill nginx'
+
+    def test_kill_service(self, compose):
+        with patch('lib.charms.docker.compose.Compose.run') as s:
+            compose.kill_service()
+            expect = 'docker-compose kill'
+
+    @patch('lib.charms.docker.compose.chdir')
+    @patch('lib.charms.docker.compose.check_call')
+    def test_run(self, ccmock, chmock):
+        compose = Compose('files/workspace', strict=False)
+        compose.start_service('nginx')
+        chmock.assert_called_with('files/workspace')
+        ccmock.assert_called_with(['docker-compose', 'up', '-d', 'nginx'])
+
+    # This test is a little ugly but is a byproduct of testing the callstack.
+    @patch('os.getcwd')
+    def test_context_manager(self, cwdmock):
+        cwdmock.return_value = '/tmp'
+        with patch('os.chdir') as chmock:
+            compose = Compose('files/workspace', strict=False)
+            with patch('lib.charms.docker.compose.check_call'):
+                compose.start_service('nginx')
+                # We can only test the return called with in this manner.
+                # So check that we at least reset context
+                chmock.assert_called_with('/tmp')
+                # TODO: test that we've actually tried to change dir context

--- a/unit_tests/test_docker_compose.py
+++ b/unit_tests/test_docker_compose.py
@@ -31,16 +31,19 @@ class TestCompose:
         with patch('lib.charms.docker.compose.Compose.run') as s:
             compose.up()
             expect = 'docker-compose up -d'
+            s.assert_called_with(expect)
 
     def test_kill_service(self, compose):
         with patch('lib.charms.docker.compose.Compose.run') as s:
             compose.kill('nginx')
             expect = 'docker-compose kill nginx'
+            s.assert_called_with(expect)
 
     def test_kill_service(self, compose):
         with patch('lib.charms.docker.compose.Compose.run') as s:
             compose.kill()
             expect = 'docker-compose kill'
+            s.assert_called_with(expect)
 
     @patch('lib.charms.docker.compose.chdir')
     @patch('lib.charms.docker.compose.check_output')

--- a/unit_tests/test_docker_compose.py
+++ b/unit_tests/test_docker_compose.py
@@ -23,30 +23,30 @@ class TestCompose:
 
     def test_start_service(self, compose):
         with patch('lib.charms.docker.compose.Compose.run') as s:
-            compose.start_service('nginx')
+            compose.up('nginx')
             expect = 'docker-compose up -d nginx'
             s.assert_called_with(expect)
 
     def test_start_default_formation(self, compose):
         with patch('lib.charms.docker.compose.Compose.run') as s:
-            compose.start_service()
+            compose.up()
             expect = 'docker-compose up -d'
 
     def test_kill_service(self, compose):
         with patch('lib.charms.docker.compose.Compose.run') as s:
-            compose.kill_service('nginx')
+            compose.kill('nginx')
             expect = 'docker-compose kill nginx'
 
     def test_kill_service(self, compose):
         with patch('lib.charms.docker.compose.Compose.run') as s:
-            compose.kill_service()
+            compose.kill()
             expect = 'docker-compose kill'
 
     @patch('lib.charms.docker.compose.chdir')
-    @patch('lib.charms.docker.compose.check_call')
+    @patch('lib.charms.docker.compose.check_output')
     def test_run(self, ccmock, chmock):
         compose = Compose('files/workspace', strict=False)
-        compose.start_service('nginx')
+        compose.up('nginx')
         chmock.assert_called_with('files/workspace')
         ccmock.assert_called_with(['docker-compose', 'up', '-d', 'nginx'])
 
@@ -56,8 +56,8 @@ class TestCompose:
         cwdmock.return_value = '/tmp'
         with patch('os.chdir') as chmock:
             compose = Compose('files/workspace', strict=False)
-            with patch('lib.charms.docker.compose.check_call'):
-                compose.start_service('nginx')
+            with patch('lib.charms.docker.compose.check_output'):
+                compose.up('nginx')
                 # We can only test the return called with in this manner.
                 # So check that we at least reset context
                 chmock.assert_called_with('/tmp')

--- a/unit_tests/test_docker_workspace.py
+++ b/unit_tests/test_docker_workspace.py
@@ -1,0 +1,35 @@
+from lib.charms.docker.workspace import Workspace
+import pytest
+from mock import patch
+
+class TestDockerOpts:
+
+    def test_init_docker_sets_context_to_compose(self):
+        w = Workspace("/tmp/docker-test")
+        assert w.path is "/tmp/docker-test"
+        assert w.context is "compose"
+
+    def test_init_docker_sets_context_to_docker(self):
+        w = Workspace("/tmp/docker-test", context="docker")
+        assert w.path is "/tmp/docker-test"
+        assert w.context is "docker"
+
+    def test_invalid_workspace(self):
+        w = Workspace("/tmp/docker-test")
+        with pytest.raises(OSError):
+            w.validate()
+
+    def test_invalid_docker_workspace(self):
+        w = Workspace("/tmp/docker-test", context="docker")
+        with pytest.raises(OSError):
+            w.validate()
+
+    def test_to_string(self):
+        w = Workspace("/tmp/docker-test")
+        assert "{}".format(w) == "/tmp/docker-test"
+
+    def test_valid_workspace(self):
+        with patch('os.path.isfile') as m:
+            m.return_value = True
+            w = Workspace("/tmp/docker-test")
+            assert w.validate() is True


### PR DESCRIPTION
Includes service wrappers for Docker, DockerCompose

This is a breakout of lib concerns for the Docker charm base, which includes
a CLI compatible wrapper for executing docker commands in given contexts.
This is all convenience for the charm author - instead of littering
subprocess.check_call or subprocess.check_output methods in their hook
code. This abstraction allows for a clean API to perform common tasks.

    Example Usage - use the bootstrap docker daemon to start flannel:

        from charms.docker import Docker
        d = Docker(socket="unix:///var/run/docker-bootstrap.sock")
        if d.running():
            d.run('quay.io/flannel/flannel', ports="4001:4001")
            hookenv.open_port(4001)
 Example Usage for DockerCompose - spin up nginx out of a composer formation

        from charms.docker.compose import Compose
        c = Compose('files/nginx-webhead')
        c.start_service('nginx')

The modules are further documented in the source files.

All the modules are tested via `tox` - after cloning the repository

        pip install tox
        tox