### PR TITLE
Adds the skip_install layer option

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,6 @@
 includes: ['layer:basic']
+defines:
+  skip-install:
+    description: Useful when creating docker subordinates, skip the install routine
+    type: boolean
+    default: false

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -38,6 +38,7 @@ def install():
     if layer_opts['skip-install']:
         set_state('docker.available')
         set_state('docker.ready')
+        return
 
     status_set('maintenance', 'Installing Docker and AUFS')
     # Using getenv will return '' if CHARM_DIR is not an environment variable.


### PR DESCRIPTION
This is useful when building layer-docker based subordinates. The charm
has a self-relationship that is capable of denoting we are connecting
to an already juju maintained version of docker on the host. Why sit
through the implicit 40 sconds of probing when we can skip and get
directly to the workload.

Default behavior is to run the install hook though.