### PR TITLE
Encapsulate docker-compose in the wheelhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ def start_my_workload():
     # do something with docker
 ```
 
+### Layer Options
+
+##### skip-install
+
+Skips the installation of docker and raises the `docker.available` state. This
+is particularly useful when programming subordinate charms from layer-docker,
+where you know docker is already installed on the host. This allows you to
+skip the potential 90 second install routine, and go straight to deploying
+your application.
+
 ### Docker Compose
 
  This layer installs the 'docker-compose' python package from pypi. So

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,5 @@
 includes: ['layer:basic']
+repo: git@github.com:juju-solutions/layer-docker.git
 defines:
   skip-install:
     description: Useful when creating docker subordinates, skip the install routine

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,5 +1,5 @@
 includes: ['layer:basic']
-repo: git@github.com:juju-solutions/layer-docker.git
+repo: https://github.com/juju-solutions/layer-docker.git
 defines:
   skip-install:
     description: Useful when creating docker subordinates, skip the install routine

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -48,9 +48,6 @@ def install():
     status_set('active', 'Docker installed, cycling for extensions')
     set_state('docker.ready')
 
-    check_call(['apt-get', 'install', '-y', 'docker-compose'])
-    # Leave a status message that Docker is installed.
-
     # Make with the adding of the users to the groups
     check_call(['usermod', '-aG', 'docker', 'ubuntu'])
 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,2 @@
 charms.docker>=0.0.1,<=2.0.0
+docker-compose>=1.0.0,<=2.0.0


### PR DESCRIPTION
Docker-compose has been pulled from the upstream docker ppa, which was weird, as it existed for a couple weeks. Regardless, installing from PIP on the production system is iffy. I think installing from the wheelhouse and keeping docker-compose encapsulated in the charm is the best path forward for now.

This commit also rolls up a few cleanup operations around the charm such as updating the readme, and adding a repo key to layer.yaml