### PR TITLE
pin docker-py

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 charms.docker>=0.0.1,<=2.0.0
+docker-py==1.7.2
 docker-compose>=1.0.0,<=2.0.0


### PR DESCRIPTION
Now that we are installing docker-compose in the wheelhouse, there's an
issue with its linking against dockerpy, which is fighting with the
setuptools in the wheelhouse/venv (i'm not sure which/how/etc.)

This is related to docker/docker-py#1019