### PR TITLE
Once and for all deal with dockerpy's brokenness

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,5 @@
 includes: ['layer:basic']
+tactics: ['tactics.docker.DockerWheelhouseTactic']
 repo: https://github.com/juju-solutions/layer-docker.git
 defines:
   skip-install:

--- a/tactics/docker.py
+++ b/tactics/docker.py
@@ -1,20 +1,20 @@
 from charmtools.build.tactics import WheelhouseTactic
 
-
+# The references to process, path, and tempfile are implicit below because
+# they come from the global scope of charmtools.utils which gets passed in during 
+# charmtools.utils.load_class
+# Investigate there if there is abrupt breakage here.
 class DockerWheelhouseTactic(WheelhouseTactic):
     def __call__(self, venv=None):
-        # this was due to some weird scoping issue during execution.
-        # investigate more later
-        from charmtools import utils
         create_venv = venv is None
         venv = venv or path(tempfile.mkdtemp())
         pip = venv / 'bin' / 'pip3'
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
-            utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
-            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
-        utils.Process((pip, 'install', '-U', 'setuptools')).exit_on_error()()  # custom bit
+            Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
+            Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
+        Process((pip, 'install', '-U', 'setuptools')).exit_on_error()()  # custom bit
         for tactic in self.previous:
             tactic(venv)
         self._add(pip, wheelhouse, '-r', self.entity)

--- a/tactics/docker.py
+++ b/tactics/docker.py
@@ -3,6 +3,8 @@ from charmtools.build.tactics import WheelhouseTactic
 
 class DockerWheelhouseTactic(WheelhouseTactic):
     def __call__(self, venv=None):
+        # this was due to some weird scoping issue during execution.
+        # investigate more later
         from charmtools import utils
         create_venv = venv is None
         venv = venv or path(tempfile.mkdtemp())
@@ -10,7 +12,6 @@ class DockerWheelhouseTactic(WheelhouseTactic):
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
-            import pdb; pdb.set_trace()
             utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
             utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
         utils.Process((pip, 'install', '-U', 'setuptools')).exit_on_error()()  # custom bit

--- a/tactics/docker.py
+++ b/tactics/docker.py
@@ -1,10 +1,16 @@
 from charmtools.build.tactics import WheelhouseTactic
+from charmtools.utils import Process
+import tempfile
+from path import Path as path
 
-# The references to process, path, and tempfile are implicit below because
-# they come from the global scope of charmtools.utils which gets passed in during 
-# charmtools.utils.load_class
-# Investigate there if there is abrupt breakage here.
+
 class DockerWheelhouseTactic(WheelhouseTactic):
+    ''' The references to process, path, and tempfile are implicit
+    below because  they come from the global scope of
+    charmtools.utils which gets passed in during
+    charmtools.utils.load_class
+    Investigate there if there is abrupt breakage here.
+    '''
     def __call__(self, venv=None):
         create_venv = venv is None
         venv = venv or path(tempfile.mkdtemp())
@@ -12,9 +18,9 @@ class DockerWheelhouseTactic(WheelhouseTactic):
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
-            Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
-            Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
-        Process((pip, 'install', '-U', 'setuptools')).exit_on_error()()  # custom bit
+            Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()  # noqa
+            Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()  # noqa
+        Process((pip, 'install', '-U', 'setuptools')).exit_on_error()()  # noqa
         for tactic in self.previous:
             tactic(venv)
         self._add(pip, wheelhouse, '-r', self.entity)

--- a/tactics/docker.py
+++ b/tactics/docker.py
@@ -1,0 +1,21 @@
+from charmtools.build.tactics import WheelhouseTactic
+
+
+class DockerWheelhouseTactic(WheelhouseTactic):
+    def __call__(self, venv=None):
+        from charmtools import utils
+        create_venv = venv is None
+        venv = venv or path(tempfile.mkdtemp())
+        pip = venv / 'bin' / 'pip3'
+        wheelhouse = self.target.directory / 'wheelhouse'
+        wheelhouse.mkdir_p()
+        if create_venv:
+            import pdb; pdb.set_trace()
+            utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
+            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
+        utils.Process((pip, 'install', '-U', 'setuptools')).exit_on_error()()  # custom bit
+        for tactic in self.previous:
+            tactic(venv)
+        self._add(pip, wheelhouse, '-r', self.entity)
+        if create_venv:
+            venv.rmtree_p()

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,3 @@
 charms.docker>=0.0.1,<=2.0.0
-docker-py==1.7.2
 docker-compose>=1.0.0,<=2.0.0
 vcversioner>=2.0.0,<=3.0.0

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,5 @@
+setuptools>=19.6,<=20.0
 charms.docker>=0.0.1,<=2.0.0
-docker-compose>=1.0.0,<=2.0.0
 vcversioner>=2.0.0,<=3.0.0
+docker-compose>=1.0.0,<=2.0.0
+


### PR DESCRIPTION
This adds a custom build tactic largely recommended by coryfu, however, it needs additional work to be a clean solution.

This requires some refactoring in charm-tools to clean up the wheelhouse tactic, and split into a few different methods so this becomes a 3 line tactic.

For now though, this unblocks all work with layer-docker and allows us to continue including upstream dependencies