### PR TITLE
binary text streams in python3 will be the death of me.

### DIFF
--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -84,7 +84,8 @@ def install_from_apt():
     # The url to the server that contains the docker apt packages.
     apt_url = 'https://apt.dockerproject.org'
     # Get the package architecture (amd64), not the machine hardware (x86_64)
-    arch = check_output(['dpkg', '--print-architecture']).rstrip()
+    arch = check_output(split('dpkg --print-architecture'))
+    arch = arch.decode('utf-8').rstrip()
     # Get the lsb information as a dictionary.
     lsb = lsb_release()
     # Ubuntu must be lowercased.


### PR DESCRIPTION
I failed to realize that check_output returned a binary text stream which renders as b'amd64' when I was expecting 'amd64' and that messed up the deb line in the code.