### PR TITLE
Adding tests for the docker layer.

### DIFF
--- a/tests/00-setup
+++ b/tests/00-setup
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x 
+
+# Check if amulet is installed before adding repository and updating apt-get.
+dpkg -s amulet
+if [ $? -ne 0 ]; then
+    sudo add-apt-repository -y ppa:juju/stable
+    sudo apt-get update -qq
+    sudo apt-get install -y amulet
+fi
+
+# Install any additional python packages or software here.

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+# This is a very basic test for this layer to make sure docker is installed.
+
+import amulet
+import unittest
+
+seconds = 1100
+
+
+class TestDeployment(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Perform a one time setup for this class deploying the charms."""
+        cls.deployment = amulet.Deployment(series='trusty')
+
+        cls.deployment.add('docker')
+
+        try:
+            cls.deployment.setup(timeout=seconds)
+            cls.deployment.sentry.wait()
+        except amulet.helpers.TimeoutError:
+            message = "The deploy did not setup in {0} seconds".format(seconds)
+            amulet.raise_status(amulet.SKIP, msg=message)
+        except:
+            raise
+        cls.unit = cls.deployment.sentry['docker'][0]
+
+    def test_docker_binary(self):
+        """Verify that the docker binary is installed, on the path and is
+        functioning properly for this architecture."""
+        # dockerbeat -version
+        output, code = self.unit.run('docker --version')
+        print(output)
+        if code != 0:
+            message = 'Docker unable to return version.'
+            amulet.raise_status(amulet.FAIL, msg=message)
+        # dockerbeat -devices
+        output, code = self.unit.run('docker info')
+        print(output)
+        if code != 0:
+            message = 'Docker unable to return system information.'
+            amulet.raise_status(amulet.FAIL, msg=message)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I ran these tests on a docker unit deployed to AWS and it worked.
```
$ ./10-deploy.py 
/usr/lib/python3/dist-packages/path.py:1719: DeprecationWarning: path is deprecated. Use Path instead.
  warnings.warn(msg, DeprecationWarning)
2016-07-12 16:22:48 Starting deployment of local.amazon:testing1
2016-07-12 16:22:50 Deploying services...
2016-07-12 16:22:58 Adding relations...
2016-07-12 16:22:59 Deployment complete in 11.50 seconds
Docker version 1.11.2, build b9f10c9
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 0
Server Version: 1.11.2
Storage Driver: devicemapper
 Pool Name: docker-202:1-264037-pool
 Pool Blocksize: 65.54 kB
 Base Device Size: 10.74 GB
 Backing Filesystem: ext4
 Data file: /dev/loop0
 Metadata file: /dev/loop1
 Data Space Used: 305.7 MB
 Data Space Total: 107.4 GB
 Data Space Available: 6.631 GB
 Metadata Space Used: 733.2 kB
 Metadata Space Total: 2.147 GB
 Metadata Space Available: 2.147 GB
 Udev Sync Supported: true
 Deferred Removal Enabled: false
 Deferred Deletion Enabled: false
 Deferred Deleted Device Count: 0
 Data loop file: /var/lib/docker/devicemapper/devicemapper/data
 Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
 Library Version: 1.02.77 (2012-10-15)
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins: 
 Volume: local
 Network: null host bridge
Kernel Version: 3.13.0-91-generic
Operating System: Ubuntu 14.04.4 LTS
OSType: linux
Architecture: x86_64
CPUs: 1
Total Memory: 3.661 GiB
Name: ip-172-31-22-249
ID: K5ZI:ZLHK:3ZT7:AB5W:NZJE:ABAG:YKWL:65EJ:PQW7:WHVI:EQVK:ARSV
Docker Root Dir: /var/lib/docker
Debug mode (client): false
Debug mode (server): false
Registry: https://index.docker.io/v1/
.
----------------------------------------------------------------------
Ran 1 test in 33.466s

OK
```
