### PR TITLE
Add charms.templating.jinja2 to wheelhouse

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,4 @@
 setuptools>=19.6,<=20.0
 charms.docker>=0.0.1,<=2.0.0
 vcversioner>=2.0.0,<=3.0.0
-
+charms.templating.jinja2>=0.0.1,<=2.0.0


### PR DESCRIPTION
layer-docker makes heavy use of templating in many situations. We should include the jinja2 render method by default to keep our subsidiary layers DRY