### PR TITLE
Upgrade pip due to the failure emitted from upstream docker libs

### DIFF
--- a/exec.d/docker-compose/charm-pre-install
+++ b/exec.d/docker-compose/charm-pre-install
@@ -7,5 +7,7 @@
 
 set +e
 apt-get install -y python-pip python3-pip
+pip install --upgrade pip
+pip3 install --upgrade pip
 pip install docker-compose
 pip3 install docker-compose


### PR DESCRIPTION
This is a temporary patch for #64, which i believe is fixed when we pack
all this in the wheelhouse.