### PR TITLE
Adds missing systemd service template

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,11 @@ options:
      Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING
      changing this option will reboot the host - use with caution on production
      services
+  http_proxy:
+     type: string
+     default:
+     description: HTTP proxy to embed as an environment setting for Docker
+  https_proxy:
+    type: string
+    default:
+    description: HTTPS proxy to embed as an environment setting for Docker daemon

--- a/templates/docker.systemd
+++ b/templates/docker.systemd
@@ -1,0 +1,33 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+EnvironmentFile=-/etc/default/docker
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
+ExecReload=/bin/kill -s HUP $MAINPID
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+{% if http_proxy or https_proxy  %}
+Environment="HTTP_PROXY={{ http_proxy }}"
+Environment="HTTPS_PROXY={{ https_proxy }}"
+{% endif %}
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Re-introduces the systemd service template which reads from
  /etc/default/docker EnvironmentFile
- Adds config options for proxy settings in systemd upstart job