### PR TITLE
Defaults to archive

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,14 @@ options:
     type: boolean
     default: false
     description: |
-     Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING
-     changing this option will reboot the host - use with caution on production
-     services
+       Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING
+       changing this option will reboot the host - use with caution on production
+       services
+  install_from_upstream:
+    type: boolean
+    default: false
+    description: |
+      Toggle installation from ubuntu archive vs the docker PPA
   http_proxy:
      type: string
      default:
@@ -20,4 +25,3 @@ options:
         URL to use for HTTPS_PROXY to be used by Docker. Only useful in closed
         environments where a proxy is the only option for routing to the
         registry to pull images
-

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -60,7 +60,10 @@ def install():
     apt_update()
     apt_install(packages)
     # Install docker-engine from apt.
-    install_from_apt()
+    if config('install_from_upstream'):
+        install_from_upstream_apt()
+    else:
+        install_from_archive_apt()
 
     opts = DockerOpts()
     render('docker.defaults', '/etc/default/docker', {'opts': opts.to_s()})
@@ -79,7 +82,12 @@ def restart_docker():
     set_state('docker.restart')
 
 
-def install_from_apt():
+def install_from_archive_apt():
+    status_set('maintenance', 'Installing docker.io from apt archive')
+    apt_install(['docker.io'], fatal=True)
+
+
+def install_from_upstream_apt():
     ''' Install docker from the apt repository. This is a pyton adaptation of
     the shell script found at https://get.docker.com/ '''
     status_set('maintenance', 'Installing docker-engine from apt')


### PR DESCRIPTION
Until this commit, layer-docker defaulted to installing from the docker
ppa. Docker 1.12 introduces a lot of interesting behavior changes behind
the scenes that can be problematic. Until we have a better pinning story
with this layer, I feel that this is the best path forward.

This will give our users the choice of which "distribution" of docker
they wish to install, and gives us the capacity to ensure we're building
against the work being put forth in the ubuntu archive. (read:
deployment into lxd containers with the docker profile)