### PR TITLE
Adds a missing template switch for daemons

### DIFF
--- a/templates/docker.systemd
+++ b/templates/docker.systemd
@@ -10,7 +10,11 @@ Type=notify
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
 EnvironmentFile=-/etc/default/docker
+{% if install_from_upstream %}
 ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
+{% else %}
+ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
+{% endif %}
 ExecReload=/bin/kill -s HUP $MAINPID
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
The recommended daemons switch between upstream packaging and the
docker.io package. This switch should help keep them in alignment when
deploying on the respective series