### PR TITLE
wild guess fix for proxy_changed step

### DIFF
--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -117,7 +117,7 @@ def toggle_docker_daemon_source():
         hookenv.log('Not touching packages.')
 
 
-@when_any('config.http_proxy.changed', 'config.https_proxy.changed')
+@when_any('config.changed.http_proxy', 'config.changed.https_proxy')
 @when('docker.ready')
 def proxy_changed():
     '''The proxy information has changed, render templates and restart the


### PR DESCRIPTION
Wild guess fix for https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/86. I'm guessing based on [this](https://github.com/juju-solutions/layer-docker/blob/f1bfadf304eb423325e6384e285e50f6c46f7489/reactive/docker.py#L83) and [this](https://github.com/juju-solutions/layer-docker/blob/f1bfadf304eb423325e6384e285e50f6c46f7489/reactive/docker.py#L225) that we just had the wrong state here. Any idea? @chuckbutler @mbruzek 