### PR TITLE
Cleanup when sdn-plugin provider has gone away

### DIFF
--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -230,10 +230,15 @@ def scrub_sdn_config():
     opts = DockerOpts()
     try:
         opts.pop('bip')
+    except KeyError:
+        hookenv.log('Unable to locate bip in Docker config.')
+        hookenv.log('Assuming no action required.')
+
+    try:
         opts.pop('mtu')
     except KeyError:
-        hookenv.log('Unable to locate bip or mtu in Docker config.')
-        hookenv.log('Assuming no action required, and restarting the daemon.')
+        hookenv.log('Unable to locate mtu in Docker config.')
+        hookenv.log('Assuming no action required.')
 
     # This method does everything we need to ensure the bridge configuration
     # has been removed. restarting the daemon restores docker with its default


### PR DESCRIPTION
In the current code in master, the docker daemon is left in a broken
state if the SDN provider ever goes away.

- renames the private method _reconfigure_docker_for_sdn to a much
  clearer indication of whats happening
- Adds state detection to determine when we should stop workloads and
  reconfigure the daemon
- Leverages the new methods added to the DockerOptsManager in
  charms.docker 1.11.0 for popping flags out of the dict.