### PR TITLE
Work around the 'config.changed' states firing always

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,14 +18,14 @@ options:
       Toggle installation from ubuntu archive vs the docker PPA
   http_proxy:
      type: string
-     default:
+     default: ""
      description: |
         URL to use for HTTP_PROXY to be used by Docker. Only useful in closed
         environments where a proxy is the only option for routing to the
         registry to pull images
   https_proxy:
     type: string
-    default:
+    default: ""
     description: |
         URL to use for HTTPS_PROXY to be used by Docker. Only useful in closed
         environments where a proxy is the only option for routing to the


### PR DESCRIPTION
This adds defaults of empty string instead of None/Null types which
causes interesting side-effect behavior when using the 'config.changed'
states provided by layer-basic.

This is a work-around for
https://github.com/juju-solutions/layer-basic/issues/79 manifesting in
layer-docker.