### PR TITLE
Add debug script to layer-docker

### DIFF
--- a/debug-scripts/docker
+++ b/debug-scripts/docker
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ux
+
+docker version > $DEBUG_SCRIPT_DIR/docker-version
+docker info > $DEBUG_SCRIPT_DIR/docker-info
+docker ps -a > $DEBUG_SCRIPT_DIR/docker-ps
+docker images -a > $DEBUG_SCRIPT_DIR/docker-images

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,5 +1,6 @@
 includes: 
   - 'layer:basic'
+  - 'layer:debug'
   - 'interface:sdn-plugin'
   - 'interface:dockerhost'
 repo: https://github.com/juju-solutions/layer-docker.git


### PR DESCRIPTION
This adds the `debug` action to layer-docker, along with a debug script to gather docker info. See [layer-debug](https://github.com/charms/layer-debug) for more info.

Additional discussion, where we decided this belongs in layer-docker, is here: https://github.com/juju-solutions/kubernetes/pull/81

@chuckbutler @mbruzek @wwwtyro 