### PR TITLE
migrate to the nagios layer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,19 +37,3 @@ options:
         Comma-separated list of destinations (either domain names or IP
         addresses) that should be directly accessed, by opposition of going
         through the proxy defined above.
-  nagios_context:
-    default: "juju"
-    type: string
-    description: |
-      Used by the nrpe subordinate charm.
-      A string that will be prepended to instance name to set the host name
-      in nagios. So for instance the hostname would be something like:
-          juju-myservice-0
-      If you're running multiple environments with the same services in them
-      this allows you to differentiate between them.
-  nagios_servicegroups:
-    default: ""
-    type: string
-    description: |
-      A comma-separated list of nagios servicegroups.
-      If left empty, the nagios_context will be used as the servicegroup.

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,7 @@
 includes: 
   - 'layer:basic'
   - 'layer:debug'
+  - 'layer:nagios'
   - 'interface:dockerhost'
   - 'interface:nrpe-external-master'
   - 'interface:sdn-plugin'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,9 +14,6 @@ provides:
   dockerhost:
     interface: dockerhost
     scope: container
-  nrpe-external-master:
-    interface: nrpe-external-master
-    scope: container
   sdn-plugin:
     interface: sdn-plugin
     scope: container


### PR DESCRIPTION
Instead of specifying the nrpe-related config options and relations in
all the charms, it's better to use the nagios layer.