### PR TITLE
Add container logs to debug script

### DIFF
--- a/debug-scripts/docker
+++ b/debug-scripts/docker
@@ -5,3 +5,8 @@ docker version > $DEBUG_SCRIPT_DIR/docker-version
 docker info > $DEBUG_SCRIPT_DIR/docker-info
 docker ps -a > $DEBUG_SCRIPT_DIR/docker-ps
 docker images -a > $DEBUG_SCRIPT_DIR/docker-images
+
+mkdir $DEBUG_SCRIPT_DIR/container-logs
+for container in $(docker ps -a --format '{{.Names}}'); do
+  docker logs $container > $DEBUG_SCRIPT_DIR/container-logs/$container 2>&1
+done


### PR DESCRIPTION
This updates the debug script to grab docker logs and include them in the dump.

Follow-up to a Kubernetes debug session where container logs were absent and it would've helped us to see them.