### PR TITLE
Added series to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,8 @@ tags:
   - containers
   - layer
 subordinate: false
+series:
+  - xenial
 provides:
   dockerhost:
     interface: dockerhost


### PR DESCRIPTION
This layer needed the series tag added to the metadata.yaml in
order to build independantly.