### PR TITLE
Error when no_proxy is too long

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,4 +36,4 @@ options:
     description: |
         Comma-separated list of destinations (either domain names or IP
         addresses) that should be directly accessed, by opposition of going
-        through the proxy defined above.
+        through the proxy defined above. Must be less than 2023 characters long

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -341,7 +341,7 @@ def validate_config():
     line_prefix_len = len("Environment=\"NO_PROXY=\"\"")
     remain_len = MAX_LINE - line_prefix_len
     if len(config('no_proxy')) > remain_len:
-        raise ConfigError('no_proxy longer than {} characters.'.format(remain_len))
+        raise ConfigError('no_proxy longer than {} chars.'.format(remain_len))
 
 
 def recycle_daemon():

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -337,8 +337,11 @@ class ConfigError(Exception):
 
 def validate_config():
     '''Check that config is valid.'''
-    if len(config('no_proxy')) + len("Environment=\"NO_PROXY=\"\"") > 2048:
-        raise ConfigError('no_proxy longer than 2023 characters.')
+    MAX_LINE = 2048
+    line_prefix_len = len("Environment=\"NO_PROXY=\"\"")
+    remain_len = MAX_LINE - line_prefix_len
+    if len(config('no_proxy')) > remain_len:
+        raise ConfigError('no_proxy longer than {} characters.'.format(remain_len))
 
 
 def recycle_daemon():


### PR DESCRIPTION
no_proxy config is passed to the docker.service file. If a line in docker.service file is greater than 2048 docker will not start properly (try it now, `juju config kubernetes-worker no_proxy=".....something long...."` and then `systemctl status docker.service` on a worker).

With this PR the charm will go into an error state until you give it a properly sized no_proxy. 

Should mitigate https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/473