### PR TITLE
set state to inform kubernetes-worker that nvidia-docker is installed

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ options:
       Toggle installation from ubuntu archive vs the docker PPA (DEPRECATED please use docker_runtime instead)
   docker_runtime:
     type: string
-    default: ""
+    default: "auto"
     description: |
       docker runtime to install valid values are "upstream" (docker PPA), "nvidia" (nvidia PPA), "apt" install from ubuntu archive, or auto
   http_proxy:

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -198,6 +198,7 @@ def toggle_docker_daemon_source():
             apt_purge(dockerpackages[k])
             remove_state('docker.ready')
             remove_state('docker.available')
+            remove_state('docker-nvidia.ready')
     else:
         hookenv.log('Not touching packages.')
 
@@ -306,6 +307,7 @@ def install_from_nvidia_apt():
         check_call(['modprobe', 'nvidia'])
     except:
         hookenv.log('not reloading nvidia kmod')
+    set_state('docker-nvidia.ready')
 
 
 @when('docker.ready')


### PR DESCRIPTION
When the nvidia/cuda docker runtime is installed kubernetes needs to create the nvidia-device-plugin-daemonset  to do this it needs to know when the runtime is installed and removed. This patch adds and clears a state on install/remove it can hook in to