### PR TITLE
Move nvidia management in this layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ to the [Charm Layers](https://jujucharms.com/docs/devel/developer-layers)
 documentation on [jujucharms.com](https://jujucharms.com/docs) for more 
 information.
 
+# States
+
+The following states are set by this layer:
+
+* `cuda.supported`
+
+  This state is set when supported GPU hardware is detected.
+
+* `cuda.installed`
+
+  This state is set once CUDA-related packages are installed and configured.
+
+
 ## Using the Docker Charm
 
 Docker does not require anything by default so you can deploy the Charm by the 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ information.
 
 The following states are set by this layer:
 
-* `cuda.supported`
+* `nvidia-docker.supported`
 
   This state is set when supported GPU hardware is detected.
 
-* `cuda.installed`
+* `nvidia-docker.installed`
 
   This state is set once CUDA-related packages are installed and configured.
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,26 @@ options:
     description: |
       docker runtime to install valid values are "upstream" (docker PPA), "nvidia" (nvidia PPA), 
       "apt" (ubuntu archive), or "auto" (nvidia PPA or ubuntu archive, based on your hardware)
+  cuda_repo:
+    type: string
+    default: "9.1.85-1"
+    description: |
+      The cuda-repo package version to install.
+  nvidia-docker-package:
+    type: string
+    default: "nvidia-docker2=2.0.3+docker17.12.1-1"
+    description: |
+      The pined version of nvidia-docker2 package.
+  nvidia-container-runtime-package:
+    type: string
+    default: "nvidia-container-runtime=2.0.0+docker17.12.1-1"
+    description: |
+      The pined version of nvidia-container-runtime package.
+  docker-ce-package:
+    type: string
+    default: "docker-ce=17.12.1~ce-0~ubuntu"
+    description: |
+      The pined version of docker-ce package installed with nvidia-docker.
   http_proxy:
      type: string
      default: ""

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -297,11 +297,6 @@ def install_cuda_drivers_repo(architecture, rel, ubuntu):
     ''' Install cuda drivers this is xenial only.
      We want to install cuda-drivers only this means that the
      cuda version plays no role. Any repo will do. '''
-    architecture = arch()
-    # Get the lsb information as a dictionary.
-    lsb = host.lsb_release()
-    rel = lsb['DISTRIB_RELEASE']
-    ubuntu = str(lsb['DISTRIB_ID']).lower()
     key_file = '7fa2af80.pub'
     # distribution should be something like ubuntu1604
     distribution = '{}{}'.format(ubuntu, str(rel).replace('.', ''))

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -119,14 +119,14 @@ def install():
 
     # Install docker-engine from apt.
     runtime = determineAptSource()
-    remove_state('cuda.supported')
-    remove_state('cuda.installed')
+    remove_state('nvidia-docker.supported')
+    remove_state('nvidia-docker.installed')
     if runtime == "upstream":
         install_from_upstream_apt()
     elif runtime == "nvidia":
-        set_state('cuda.supported')
+        set_state('nvidia-docker.supported')
         install_from_nvidia_apt()
-        set_state('cuda.installed')
+        set_state('nvidia-docker.installed')
     elif runtime == "apt":
         install_from_archive_apt()
     else:

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -1,8 +1,10 @@
 import os
+import requests
 from shlex import split
 from subprocess import check_call
 from subprocess import check_output
 from subprocess import CalledProcessError
+
 
 from charmhelpers.core import host
 from charmhelpers.core import hookenv
@@ -77,7 +79,7 @@ def determineAptSource():
 
     if docker_runtime == "auto":
         out = check_output(['lspci', '-nnk']).rstrip()
-        if out.decode('utf-8').lower().count("nvidia") > 0:
+        if arch() == 'amd64' and out.decode('utf-8').lower().count("nvidia") > 0:
             docker_runtime = "nvidia"
         else:
             docker_runtime = "apt"
@@ -116,10 +118,14 @@ def install():
 
     # Install docker-engine from apt.
     runtime = determineAptSource()
+    remove_state('cuda.supported')
+    remove_state('cuda.installed')
     if runtime == "upstream":
         install_from_upstream_apt()
     elif runtime == "nvidia":
+        set_state('cuda.supported')
         install_from_nvidia_apt()
+        set_state('cuda.installed')
     elif runtime == "apt":
         install_from_archive_apt()
     else:
@@ -220,18 +226,12 @@ def install_from_upstream_apt():
     ''' Install docker from the apt repository. This is a pyton adaptation of
     the shell script found at https://get.docker.com/ '''
     status_set('maintenance', 'Installing docker-engine from upstream PPA.')
-    keyserver = 'hkp://p80.pool.sks-keyservers.net:80'
     key = '58118E89F3A912897C070ADBF76221572C52609D'
-    # Enter the server and key in the apt-key management tool.
-    cmd = 'apt-key adv --keyserver {0} --recv-keys {1}'.format(keyserver, key)
-    # "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80
-    # --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
-    check_call(split(cmd))
+    add_apt_key(key)
     # The url to the server that contains the docker apt packages.
     apt_url = 'https://apt.dockerproject.org'
     # Get the package architecture (amd64), not the machine hardware (x86_64)
-    arch = check_output(split('dpkg --print-architecture'))
-    arch = arch.decode('utf-8').rstrip()
+    architecture = arch()
     # Get the lsb information as a dictionary.
     lsb = host.lsb_release()
     # Ubuntu must be lowercased.
@@ -241,14 +241,10 @@ def install_from_upstream_apt():
     # repo can be: main, testing or experimental
     repo = 'main'
     # deb [arch=amd64] https://apt.dockerproject.org/repo ubuntu-xenial main
-    deb = 'deb [arch={0}] {1}/repo {2}-{3} {4}'.format(
-            arch, apt_url, dist, code, repo)
-    # mkdir -p /etc/apt/sources.list.d
-    if not os.path.isdir('/etc/apt/sources.list.d'):
-        os.makedirs('/etc/apt/sources.list.d')
-    # Write the docker source file to the apt sources.list.d directory.
-    with(open('/etc/apt/sources.list.d/docker.list', 'w+')) as stream:
-        stream.write(deb)
+    deb =list()
+    deb.append('deb [arch={0}] {1}/repo {2}-{3} {4}'.format(
+        architecture, apt_url, dist, code, repo))
+    write_docker_sources(deb)
     apt_update(fatal=True)
     # apt-get install -y -q docker-engine
     apt_install(['docker-engine'], fatal=True)
@@ -257,32 +253,73 @@ def install_from_upstream_apt():
 def install_from_nvidia_apt():
     ''' Install cuda docker from the nvidia apt repository. '''
     status_set('maintenance', 'Installing docker-engine from Nvidia PPA.')
-
     # Get the server and key in the apt-key management tool.
-    ksvr = 'hkp://p80.pool.sks-keyservers.net:80'
     for key in ["C95B321B61E88C1809C4F759DDCAE044F796ECB0",
                 "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]:
-        cmd = 'apt-key adv --keyserver {0} --recv-keys {1}'.format(ksvr, key)
-        check_call(split(cmd))
+        add_apt_key(key)
 
     # Get the package architecture (amd64), not the machine hardware (x86_64)
-    arch = check_output(split('dpkg --print-architecture'))
-    arch = arch.decode('utf-8').rstrip()
+    architecture = arch()
     # Get the lsb information as a dictionary.
     lsb = host.lsb_release()
     code = lsb['DISTRIB_CODENAME']
     rel = lsb['DISTRIB_RELEASE']
+    ubuntu = str(lsb['DISTRIB_ID']).lower()
     dockurl = "https://download.docker.com/linux/ubuntu"
     nvidurl = 'https://nvidia.github.io'
     repo = 'stable'
 
     deb = list()
-    deb.append('deb [arch={0}] {1} {2} {3}'.format(arch, dockurl, code, repo))
+    deb.append('deb [arch={0}] {1} {2} {3}'.format(architecture, dockurl, code, repo))
     for i in ['libnvidia-container',
               'nvidia-container-runtime',
               'nvidia-docker']:
-        deb.append('deb {0}/{1}/ubuntu{2}/{3} /'.format(nvidurl, i, rel, arch))
+        deb.append('deb {0}/{1}/ubuntu{2}/{3} /'.format(nvidurl, i, rel, architecture))
 
+    write_docker_sources(deb)
+
+    install_cuda_drivers_repo(architecture, rel, ubuntu)
+
+    apt_update(fatal=True)
+    # actually install the required packages docker-ce nvidia-docker2
+
+    docker_ce = hookenv.config('docker-ce-package')
+    nvidia_docker2 = hookenv.config('nvidia-docker-package')
+    nvidia_container_runtime = hookenv.config('nvidia-container-runtime-package')
+    apt_install(['cuda-drivers', docker_ce, nvidia_docker2, nvidia_container_runtime], fatal=True)
+
+
+def install_cuda_drivers_repo(architecture, rel, ubuntu):
+    ''' Install cuda drivers this is xenial only. We want to install cuda-drivers only
+    this means that the cuda version plays no role. Any repo will do. '''
+    architecture = arch()
+    # Get the lsb information as a dictionary.
+    lsb = host.lsb_release()
+    rel = lsb['DISTRIB_RELEASE']
+    ubuntu = str(lsb['DISTRIB_ID']).lower()
+    key_file = '7fa2af80.pub'
+    # distribution should be something like ubuntu1604
+    distribution = '{}{}'.format(ubuntu, str(rel).replace('.', ''))
+    repo_path = 'developer.download.nvidia.com/compute/' \
+                'cuda/repos/{}/x86_64'.format(distribution)
+    cmd = 'apt-key adv --fetch-keys http://{}/{}'.format(repo_path, key_file)
+    check_call(split(cmd))
+    cuda_repo_version = config('cuda_repo')
+    cuda_repo_pkg = 'cuda-repo-{}_{}_{}.deb'.format(distribution,
+                                                    cuda_repo_version, architecture)
+    repo_url = 'https://{}/{}'.format(repo_path, cuda_repo_pkg)
+    r = requests.get(repo_url)
+    r.raise_for_status()
+    with open(cuda_repo_pkg, "wb") as repo_file:
+        for chunk in r.iter_content(chunk_size=1024):
+            repo_file.write(chunk)
+    r.close()
+    cmd = 'dpkg -i  {}'.format(cuda_repo_pkg)
+    check_call(split(cmd))
+
+
+def write_docker_sources(deb):
+    '''Write docker.list under etc/apt/sources.list.d'''
     # mkdir -p /etc/apt/sources.list.d
     if not os.path.isdir('/etc/apt/sources.list.d'):
         os.makedirs('/etc/apt/sources.list.d')
@@ -290,22 +327,14 @@ def install_from_nvidia_apt():
     with(open('/etc/apt/sources.list.d/docker.list', 'w+')) as stream:
         stream.write("\n".join(deb))
 
-    apt_update(fatal=True)
 
-    # actually install the required packages docker-ce nvidia-docker2
-    apt_install(['docker-ce', 'nvidia-docker2'], fatal=True)
-
-    for m in ['nvidia_drm', 'nvidia_uvm', 'nvidia_modeset', 'nvidia']:
-        try:
-            hookenv.log('rmmod {0}'.format(m))
-            check_call(['rmmod', m])
-        except CalledProcessError:
-            hookenv.log('not unloading kmod {0}'.format(m))
-
-    try:
-        check_call(['modprobe', 'nvidia'])
-    except CalledProcessError:
-        hookenv.log('not reloading nvidia kmod')
+def add_apt_key(key):
+    '''Enter the server and key in the apt-key management tool.'''
+    keyserver = 'hkp://p80.pool.sks-keyservers.net:80'
+    cmd = 'apt-key adv --keyserver {0} --recv-keys {1}'.format(keyserver, key)
+    # "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80
+    # --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
+    check_call(split(cmd))
 
 
 @when('docker.ready')
@@ -530,3 +559,13 @@ def _remove_docker_network_bridge():
 
     # Render the config and restart docker.
     recycle_daemon()
+
+
+def arch():
+    '''Return the package architecture as a string.'''
+    # Get the package architecture for this system.
+    if not arch.architecture:
+        arch.architecture = check_output(['dpkg', '--print-architecture']).rstrip()
+        arch.architecture = arch.architecture.decode('utf-8')
+    return arch.architecture
+arch.architecture = None

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -79,7 +79,8 @@ def determineAptSource():
 
     if docker_runtime == "auto":
         out = check_output(['lspci', '-nnk']).rstrip()
-        if arch() == 'amd64' and out.decode('utf-8').lower().count("nvidia") > 0:
+        if arch() == 'amd64' \
+                and out.decode('utf-8').lower().count("nvidia") > 0:
             docker_runtime = "nvidia"
         else:
             docker_runtime = "apt"
@@ -241,7 +242,7 @@ def install_from_upstream_apt():
     # repo can be: main, testing or experimental
     repo = 'main'
     # deb [arch=amd64] https://apt.dockerproject.org/repo ubuntu-xenial main
-    deb =list()
+    deb = list()
     deb.append('deb [arch={0}] {1}/repo {2}-{3} {4}'.format(
         architecture, apt_url, dist, code, repo))
     write_docker_sources(deb)
@@ -270,11 +271,13 @@ def install_from_nvidia_apt():
     repo = 'stable'
 
     deb = list()
-    deb.append('deb [arch={0}] {1} {2} {3}'.format(architecture, dockurl, code, repo))
+    deb.append('deb [arch={0}] {1} {2} {3}'.format(architecture,
+                                                   dockurl, code, repo))
     for i in ['libnvidia-container',
               'nvidia-container-runtime',
               'nvidia-docker']:
-        deb.append('deb {0}/{1}/ubuntu{2}/{3} /'.format(nvidurl, i, rel, architecture))
+        deb.append('deb {0}/{1}/ubuntu{2}/{3} /'.format(nvidurl,
+                                                        i, rel, architecture))
 
     write_docker_sources(deb)
 
@@ -285,13 +288,15 @@ def install_from_nvidia_apt():
 
     docker_ce = hookenv.config('docker-ce-package')
     nvidia_docker2 = hookenv.config('nvidia-docker-package')
-    nvidia_container_runtime = hookenv.config('nvidia-container-runtime-package')
-    apt_install(['cuda-drivers', docker_ce, nvidia_docker2, nvidia_container_runtime], fatal=True)
+    nv_container_runtime = hookenv.config('nvidia-container-runtime-package')
+    apt_install(['cuda-drivers', docker_ce, nvidia_docker2,
+                 nv_container_runtime], fatal=True)
 
 
 def install_cuda_drivers_repo(architecture, rel, ubuntu):
-    ''' Install cuda drivers this is xenial only. We want to install cuda-drivers only
-    this means that the cuda version plays no role. Any repo will do. '''
+    ''' Install cuda drivers this is xenial only.
+     We want to install cuda-drivers only this means that the
+     cuda version plays no role. Any repo will do. '''
     architecture = arch()
     # Get the lsb information as a dictionary.
     lsb = host.lsb_release()
@@ -306,7 +311,8 @@ def install_cuda_drivers_repo(architecture, rel, ubuntu):
     check_call(split(cmd))
     cuda_repo_version = config('cuda_repo')
     cuda_repo_pkg = 'cuda-repo-{}_{}_{}.deb'.format(distribution,
-                                                    cuda_repo_version, architecture)
+                                                    cuda_repo_version,
+                                                    architecture)
     repo_url = 'https://{}/{}'.format(repo_path, cuda_repo_pkg)
     r = requests.get(repo_url)
     r.raise_for_status()
@@ -565,7 +571,8 @@ def arch():
     '''Return the package architecture as a string.'''
     # Get the package architecture for this system.
     if not arch.architecture:
-        arch.architecture = check_output(['dpkg', '--print-architecture']).rstrip()
+        arch.architecture = check_output(['dpkg',
+                                          '--print-architecture']).rstrip()
         arch.architecture = arch.architecture.decode('utf-8')
     return arch.architecture
-arch.architecture = None
+arch.architecture = None # noqa: E261, E305

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -2,3 +2,4 @@ setuptools>=19.6,<=20.0
 charms.docker>=0.0.1,<=2.0.0
 vcversioner>=2.0.0,<=3.0.0
 charms.templating.jinja2>=0.0.1,<=2.0.0
+requests>=2.0.0,<3.0.0


### PR DESCRIPTION
Moving the cuda-driver installation inside this layer simplifies things a lot. We do not need to care about loading and unloading kernel modules.

The nvidia docker we deploy is pinned to a specific version. The reason is I go the following error today:

```
 The following packages have unmet dependencies:
 nvidia-docker2 : Depends: docker-ce (= 17.12.1~ce-0~ubuntu) but 18.03.0~ce-0~ubuntu is to be installed or
                           docker-ee (= 17.12.1~ee-0~ubuntu) but it is not installable
E: Unable to correct problems, you have held broken packages.
```

Already reported in https://github.com/NVIDIA/nvidia-docker/issues/643

This has happen in the past: https://github.com/NVIDIA/nvidia-docker/issues/540

So I would rather be safe and pin the versions I know they work and offer the config option to change the pins if needed.

