### PR TITLE
Remove deprecated --use-wheel

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 skip_missing_interpreters = True
 
 [testenv]
-install_command = pip install {opts} --pre --use-wheel {packages}
+install_command = pip install {opts} --pre {packages}
 deps =
     flake8
 


### PR DESCRIPTION
Recent builds started failing with `no such option: --use-wheel`. Seems that --use-wheel is deprecated since pip 7 and remove in pip 9. We could have the option of `--only-binary :all:` but I do not think we need to be that strict.

This will unblock the build.