### PR TITLE
make apt key server configurable (fixes #120)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,8 @@
 options:
+  apt-key-server:
+    description: APT Key Server
+    type: string
+    default: 'hkp://keyserver.ubuntu.com:80'
   docker-opts:
     type: string
     default : ""
@@ -20,7 +24,7 @@ options:
     type: string
     default: "auto"
     description: |
-      docker runtime to install valid values are "upstream" (docker PPA), "nvidia" (nvidia PPA), 
+      docker runtime to install valid values are "upstream" (docker PPA), "nvidia" (nvidia PPA),
       "apt" (ubuntu archive), or "auto" (nvidia PPA or ubuntu archive, based on your hardware)
   cuda_repo:
     type: string

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,4 @@
-includes: 
+includes:
   - 'layer:basic'
   - 'layer:debug'
   - 'layer:nagios'

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -157,6 +157,11 @@ def toggle_install_from_upstream():
     toggle_docker_daemon_source()
 
 
+@when('config.changed.apt-key-server', 'docker.ready')
+def toggle_install_with_new_keyserver():
+    toggle_docker_daemon_source()
+
+
 @when('config.changed.docker_runtime', 'docker.ready')
 def toggle_docker_daemon_source():
     ''' A disruptive reaction to config changing that will remove the existing
@@ -331,7 +336,7 @@ def write_docker_sources(deb):
 
 def add_apt_key(key):
     '''Enter the server and key in the apt-key management tool.'''
-    keyserver = 'hkp://p80.pool.sks-keyservers.net:80'
+    keyserver = config('apt-key-server')
     cmd = 'apt-key adv --keyserver {0} --recv-keys {1}'.format(keyserver, key)
     # "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80
     # --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"


### PR DESCRIPTION
Default the key server to `hkp://keyserver.ubuntu.com:80`, but let users configure as needed.  On config changed, re-install docker via `toggle_docker_daemon_source()`.

Threw in a couple lint fixes for funzies.