### PR TITLE
Move to latest cuda and remove version pins of nvidia docker stack

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,22 +28,22 @@ options:
       "apt" (ubuntu archive), or "auto" (nvidia PPA or ubuntu archive, based on your hardware)
   cuda_repo:
     type: string
-    default: "9.1.85-1"
+    default: "10.0.130-1"
     description: |
       The cuda-repo package version to install.
   nvidia-docker-package:
     type: string
-    default: "nvidia-docker2=2.0.3+docker17.12.1-1"
+    default: "nvidia-docker2"
     description: |
       The pined version of nvidia-docker2 package.
   nvidia-container-runtime-package:
     type: string
-    default: "nvidia-container-runtime=2.0.0+docker17.12.1-1"
+    default: "nvidia-container-runtime"
     description: |
       The pined version of nvidia-container-runtime package.
   docker-ce-package:
     type: string
-    default: "docker-ce=17.12.1~ce-0~ubuntu"
+    default: "docker-ce"
     description: |
       The pined version of docker-ce package installed with nvidia-docker.
   http_proxy:

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -264,6 +264,12 @@ def install_from_nvidia_apt():
                 "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]:
         add_apt_key(key)
 
+    # Install key for nvidia-docker. This key changes frequently ([expires: 2019-09-20])
+    # so we should do what the official docs say and not try to get it through its
+    # fingerprint.
+    cmd = "apt-key adv --fetch-keys https://nvidia.github.io/nvidia-docker/gpgkey".split()
+    check_call(cmd)
+
     # Get the package architecture (amd64), not the machine hardware (x86_64)
     architecture = arch()
     # Get the lsb information as a dictionary.

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -261,8 +261,7 @@ def install_from_nvidia_apt():
     ''' Install cuda docker from the nvidia apt repository. '''
     status_set('maintenance', 'Installing docker-engine from Nvidia PPA.')
     # Get the server and key in the apt-key management tool.
-    for key in ["C95B321B61E88C1809C4F759DDCAE044F796ECB0",
-                "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]:
+    for key in ["9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]:
         add_apt_key(key)
 
     # Install key for nvidia-docker. This key changes frequently

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -264,10 +264,11 @@ def install_from_nvidia_apt():
                 "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]:
         add_apt_key(key)
 
-    # Install key for nvidia-docker. This key changes frequently ([expires: 2019-09-20])
-    # so we should do what the official docs say and not try to get it through its
-    # fingerprint.
-    cmd = "apt-key adv --fetch-keys https://nvidia.github.io/nvidia-docker/gpgkey".split()
+    # Install key for nvidia-docker. This key changes frequently
+    # ([expires: 2019-09-20]) so we should do what the official docs say and
+    # not try to get it through its fingerprint.
+    cmd = "apt-key adv --fetch-keys " \
+          "https://nvidia.github.io/nvidia-docker/gpgkey".split()
     check_call(cmd)
 
     # Get the package architecture (amd64), not the machine hardware (x86_64)

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -261,9 +261,7 @@ def install_from_nvidia_apt():
     ''' Install cuda docker from the nvidia apt repository. '''
     status_set('maintenance', 'Installing docker-engine from Nvidia PPA.')
     # Get the server and key in the apt-key management tool.
-    for key in ["9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]:
-        add_apt_key(key)
-
+    add_apt_key("9DC858229FC7DD38854AE2D88D81803C0EBFCD88")
     # Install key for nvidia-docker. This key changes frequently
     # ([expires: 2019-09-20]) so we should do what the official docs say and
     # not try to get it through its fingerprint.


### PR DESCRIPTION
We update the default values for cuda 10.0.130-1 and the nvidia docker stack. For the nvidia docker stack we removed the version pins as the package dependencies in bionic seem to be correct.

We also install the nvidia docker repo key from the `https://nvidia.github.io/nvidia-docker/gpgkey` as suggested in the official docs. This way we will not need to search for a new key fingerprint and re-release next time this key expires.

Fixes: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/664