### PR TITLE
Ability to configure custom Docker repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,8 +31,8 @@ options:
     type: string
     default: ""
     description: |
-      Custom Docker repository, given in deb format.  Use `{ARCH}` to determine archetecture at
-      runime.  Use `{CODE}` to set release codename.  E.g.
+      Custom Docker repository, given in deb format.  Use `{ARCH}` to determine architecture at
+      runtime.  Use `{CODE}` to set release codename.  E.g.
       `deb [arch={ARCH}] https://download.docker.com/linux/ubuntu {CODE} stable`.
   docker_runtime_key_url:
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -24,8 +24,26 @@ options:
     type: string
     default: "auto"
     description: |
-      docker runtime to install valid values are "upstream" (docker PPA), "nvidia" (nvidia PPA),
-      "apt" (ubuntu archive), or "auto" (nvidia PPA or ubuntu archive, based on your hardware)
+      Docker runtime to install valid values are "upstream" (docker PPA), "nvidia" (nvidia PPA),
+      "apt" (ubuntu archive), "auto" (nvidia PPA or ubuntu archive, based on your hardware),
+      or "custom" (set repository URL, validation key URL and package name).
+  docker_runtime_repo:
+    type: string
+    default: ""
+    description: |
+      Custom Docker repository, given in deb format.  Use `{ARCH}` to determine archetecture at
+      runime.  Use `{CODE}` to set release codename.  E.g.
+      `deb [arch={ARCH}] https://download.docker.com/linux/ubuntu {CODE} stable`.
+  docker_runtime_key_url:
+    type: string
+    default: ""
+    description: |
+      Custom Docker repository validation key URL.
+  docker_runtime_package:
+    type: string
+    default: ""
+    description: |
+      Custom Docker repository package name.
   cuda_repo:
     type: string
     default: "10.0.130-1"

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -145,7 +145,8 @@ def install():
     elif runtime == "apt":
         install_from_archive_apt()
     elif runtime == "custom":
-        install_from_custom_apt()
+        if not install_from_custom_apt():
+            return False  # If install fails, stop.
     else:
         hookenv.log('unknown runtime {0}'.format(runtime))
         return False

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -49,7 +49,7 @@ from charms import layer
 # react to the proper event.
 
 dockerpackages = {'apt': ['docker.io'],
-                  'upstream': ['docker-engine'],
+                  'upstream': ['docker-ce'],
                   'nvidia': ['docker-ce',
                              'nvidia-docker2',
                              'nvidia-container-runtime',
@@ -64,6 +64,7 @@ def holdall():
 def unholdall():
     for k in dockerpackages.keys():
         apt_unhold(dockerpackages[k])
+
 
 def set_custom_docker_package():
     """
@@ -131,7 +132,7 @@ def install():
     apt_update()
     apt_install(packages)
 
-    # Install docker-engine from apt.
+    # Install Docker from apt.
     remove_state('nvidia-docker.supported')
     remove_state('nvidia-docker.installed')
     runtime = determineAptSource()
@@ -249,7 +250,7 @@ def install_from_archive_apt():
 def install_from_upstream_apt():
     ''' Install docker from the apt repository. This is a pyton adaptation of
     the shell script found at https://get.docker.com/ '''
-    status_set('maintenance', 'Installing docker-engine from upstream PPA.')
+    status_set('maintenance', 'Installing docker-ce from upstream PPA.')
     key_url = 'https://download.docker.com/linux/ubuntu/gpg'
     add_apt_key_url(key_url)
     # The url to the server that contains the docker apt packages.
@@ -353,6 +354,7 @@ def install_from_custom_apt():
 
     add_apt_key_url(key_url)
     write_docker_sources([repo_string.format(**format_dictionary)])
+    apt_update()
     apt_install([package_name])
 
 

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -310,15 +310,21 @@ def install_from_custom_apt():
     package_name = config('docker_runtime_package')
 
     if not repo_string:
-        hookenv.log('`docker_runtime_repo` must be set')
+        message = '`docker_runtime_repo` must be set'
+        hookenv.log(message)
+        hookenv.status_set('blocked', message)
         return False
 
     if not key_url:
-        hookenv.log('`docker_runtime_key_url` must be set')
+        message = '`docker_runtime_key_url` must be set'
+        hookenv.log(message)
+        hookenv.status_set('blocked', message)
         return False
 
     if not package_name:
-        hookenv.log('`docker_runtime_package` must be set')
+        message = '`docker_runtime_package` must be set'
+        hookenv.log(message)
+        hookenv.status_set('blocked', message)
         return False
 
     lsb = host.lsb_release()


### PR DESCRIPTION
Tested with `juju deploy ./builds/docker --config docker_runtime=custom --config docker_runtime_repo="deb [arch={ARCH}] https://download.docker.com/linux/ubuntu {CODE} stable" --config docker_runtime_key_url="https://download.docker.com/linux/ubuntu/gpg" --config docker_runtime_package=docker-ce`

```
$ docker version
Client:
 Version:           18.09.0
 API version:       1.39
 Go version:        go1.10.4
 Git commit:        4d60db4
 Built:             Wed Nov  7 00:48:57 2018
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          18.09.0
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.4
  Git commit:       4d60db4
  Built:            Wed Nov  7 00:16:44 2018
  OS/Arch:          linux/amd64
  Experimental:     false
```