### PR TITLE
Fix bug from this change ( Adding a run-action to upgrade Docker #135 )

### DIFF
--- a/lib/charms/layer/docker.py
+++ b/lib/charms/layer/docker.py
@@ -64,6 +64,7 @@ def render_configuration_template(service=False):
         '/etc/default/docker',
         {
             'opts': opts.to_s(),
+            'manual': config('docker-opts'),
             'docker_runtime': runtime
         }
     )


### PR DESCRIPTION
This to fix a regression form the last change . 

Any docker-opts in the kubernetes worker charm was ignored .

Most common usage is usage of insecure registry 
