### PR TITLE
Change charms to use juju-http{s}-proxy model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Charm for Docker
 
-This charm deploys the [Docker](http://docker.com) engine within Juju. Docker 
-is an open platform for developers and sysadmins to build, ship, and run 
+This charm deploys the [Docker](http://docker.com) engine within Juju. Docker
+is an open platform for developers and sysadmins to build, ship, and run
 distributed applications in containers.
 
-Docker containers wrap a piece of software in a complete file system that 
+Docker containers wrap a piece of software in a complete file system that
 contains everything needed to run an application on a server.
 
-Docker focuses on distributing applications as containers that can be quickly 
-assembled from components that are run the same on different servers without 
-environmental dependencies. This eliminates the friction between development, 
+Docker focuses on distributing applications as containers that can be quickly
+assembled from components that are run the same on different servers without
+environmental dependencies. This eliminates the friction between development,
 QA, and production environments.
 
-Most people will want to extend this charm to make their Docker container or 
-application deployable from Juju. The 
+Most people will want to extend this charm to make their Docker container or
+application deployable from Juju. The
 [Charm layer](https://github.com/juju-solutions/layer-docker) can be extended to
 include docker container along with additional operational code. Please refer
 to the [Charm Layers](https://jujucharms.com/docs/devel/developer-layers)
-documentation on [jujucharms.com](https://jujucharms.com/docs) for more 
+documentation on [jujucharms.com](https://jujucharms.com/docs) for more
 information.
 
 # States
@@ -35,7 +35,7 @@ The following states are set by this layer:
 
 ## Using the Docker Charm
 
-Docker does not require anything by default so you can deploy the Charm by the 
+Docker does not require anything by default so you can deploy the Charm by the
 following command.
 
 ```
@@ -47,7 +47,7 @@ juju deploy docker
 16.04.
 
 Once deployed you have a docker-engine running on a unit in Juju. You can open
-a session to that unit and issue the `docker` command to start using it 
+a session to that unit and issue the `docker` command to start using it
 right away.
 
 ```
@@ -60,13 +60,15 @@ $ docker run hello-world
 
 Scaling out the Charm is as simple as adding additional docker units
 with Juju `add-unit` command to expand your cluster. However, you will need an
-SDN solution to provide cross host networking. See the Known Limitations and 
+SDN solution to provide cross host networking. See the Known Limitations and
 issues about this.
 
 # Configuration
 
 See [config.yaml](config.yaml) for
 list of configuration options.
+
+> Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
 
 ## Docker Compose
 
@@ -77,17 +79,17 @@ and logging.
 
 # Contact Information
 
-This Charm is available at <https://jujucharms.com/docker> and contains the 
-open source operations code to deploy on all public clouds in the Juju 
+This Charm is available at <https://jujucharms.com/docker> and contains the
+open source operations code to deploy on all public clouds in the Juju
 ecosystem.
 
 ## Docker links
 
   - The [Docker homepage](https://www.docker.com/)
-  - Docker [documentation](https://docs.docker.com/) for help with Docker 
+  - Docker [documentation](https://docs.docker.com/) for help with Docker
   commands.
   - Docker [forums](https://forums.docker.com/) for community discussions.
-  - Check the Docker [issue tracker](https://github.com/docker/docker/issues) 
+  - Check the Docker [issue tracker](https://github.com/docker/docker/issues)
   for bugs or problems with the Docker software.
   - The [layer-docker](https://github.com/juju-solutions/layer-docker) is
   the GitHub repository that contains the reactive code to build this Charm.

--- a/lib/charms/layer/docker.py
+++ b/lib/charms/layer/docker.py
@@ -57,15 +57,13 @@ def render_configuration_template(service=False):
     """
     opts = DockerOpts()
     config = hookenv.config
-    
+
     # If juju environment variables are defined, take precedent
     # over config.yaml.
     # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
     environment_config = hookenv.env_proxy_settings()
     if environment_config is not None:
-        config.update(environment_config)
-
-    hookenv.log("CONFIG: %s" % config, 'DEBUG')
+        config().update(environment_config)
 
     runtime = determine_apt_source()
 

--- a/lib/charms/layer/docker.py
+++ b/lib/charms/layer/docker.py
@@ -57,6 +57,16 @@ def render_configuration_template(service=False):
     """
     opts = DockerOpts()
     config = hookenv.config
+    
+    # If juju environment variables are defined, take precedent
+    # over config.yaml.
+    # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
+    environment_config = hookenv.env_proxy_settings()
+    if environment_config is not None:
+        config.update(environment_config)
+
+    hookenv.log("CONFIG: %s" % config, 'DEBUG')
+
     runtime = determine_apt_source()
 
     render(


### PR DESCRIPTION
Changed charm to use juju-http{s}-proxy-settings when these keys are defined.

[LP#1831712](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1831712)

