### PR TITLE
Change charms to use juju-http{s}-proxy model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ issues about this.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
-> Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
-
 ## Docker Compose
 
 This Charm also installs the 'docker-compose' python package using pip. So

--- a/lib/charms/layer/docker.py
+++ b/lib/charms/layer/docker.py
@@ -58,10 +58,6 @@ def render_configuration_template(service=False):
     opts = DockerOpts()
     config = hookenv.config
 
-    # If juju environment variables are defined, take precedent
-    # over config.yaml.
-    # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
-    # &: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
     environment_config = hookenv.env_proxy_settings()
     modified_config = dict(config())
     parsed_hosts = ""
@@ -83,8 +79,9 @@ def render_configuration_template(service=False):
             'NO_PROXY': parsed_hosts,
             'no_proxy': parsed_hosts
         })
-
-        modified_config.update(environment_config)
+        for key in ['http_proxy', 'https_proxy', 'no_proxy']:
+            if not modified_config.get(key):
+                modified_config[key] = environment_config.get(key)
 
     runtime = determine_apt_source()
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/layer-docker-registry/+bug/1832336

Built on the work of @VariableDeclared from https://github.com/juju-solutions/layer-docker/pull/138 (thanks!).

I tested this by building the [docker-registry charm](https://github.com/canonicalltd/docker-registry-charm) with these changes. I deployed it and confirmed the following:
1. When no charm or model proxy configs are set, the service file renders with no proxy.
2. When charm proxy configs are set, they are included in the service file.
3. When model proxy configs are set, they are included in the service file.
4. When both charm and model proxy configs are set, the charm configs are used.
5. juju-no-proxy CIDRs are expanded correctly before being rendered in the service file